### PR TITLE
v0.19, Enable CLEAN_AFTER_BUILD Argument For Preprocess Filter

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,9 @@
 Revision history for Perl extension Inline::Filters.
 
+0.19 2017-01-24 (wbraswell)
+	- Enable CLEAN_AFTER_BUILD Argument In Preprocess Filter
+        For Compatibility With gdb For Inline::C(PP) Debugging
+
 0.18 2016-09-07 (rurban)
 	- Allow a space in paths (#3) - bulk88
 

--- a/Filters.pm
+++ b/Filters.pm
@@ -1,7 +1,7 @@
 package Inline::Filters;
 use strict;
 use Config;
-our $VERSION = "0.18";
+our $VERSION = "0.19";
 use File::Spec;
  
 #============================================================================
@@ -132,7 +132,13 @@ sub Preprocess {
     open $PROCESSED, "$cpp \"$tmpfile\" |" or die $!;
     $code = join '', <$PROCESSED>;
     close $PROCESSED;
-    unlink $tmpfile;
+
+    # default yes, will remove Filters*.c files, this is the same config option used by Inline::C(PP);
+    # must disable when using gdb to debug Inline::C(PP) code
+    if ((not defined $ilsm->{CONFIG}->{CLEAN_AFTER_BUILD}) or $ilsm->{CONFIG}->{CLEAN_AFTER_BUILD}) {
+        unlink $tmpfile;
+    }
+
     return $code;
 }
 

--- a/Filters.pod
+++ b/Filters.pod
@@ -94,6 +94,8 @@ and conditional code before parsing. For example:
 The code shown above will not parse correctly without the Preprocess filter,
 since the Inline::CPP grammar can't understand preprocessor directives.
 
+=head3 CPPFLAGS Argument
+
 Also available is the CPPFLAGS argument, to specify C preprocessor directives.
 
     use Inline C => <<'END' => CPPFLAGS => ' -DPREPROCESSOR_DEFINE' => FILTERS => 'Preprocess';
@@ -105,6 +107,43 @@ Also available is the CPPFLAGS argument, to specify C preprocessor directives.
     END
 
 The code shown above will return 4321 when foo() is called.
+
+=head3 CLEAN_AFTER_BUILD Argument
+
+By default, the Preprocess filter deletes all F<Filters*.c> files it creates.
+If you set the CLEAN_AFTER_BUILD flag to false, then the C<Filters*.c> files
+will not be deleted; this is necessary when using C<gdb> to debug Inline::C
+and Inline::CPP programs which utilize the Preprocess filter.
+
+If you do not set the CLEAN_AFTER_BUILD flag to false, you will likely end up
+with a "No such file or directory" error in gdb:
+
+    use Inline C => <<'END' => FILTERS => 'Preprocess';
+    // your code here
+    END
+
+$ gdb /usr/bin/perl
+(gdb) run ./my_script.pl arg0 arg1
+...
+Thread 1 "perl" received signal SIGSEGV, Segmentation fault.
+MyPackage::my_method (this=this@entry=0x1234567, my_arg=my_arg@entry=23)
+    at /.../_Inline/build/eval_XXX_YYYY/FiltersZZZZ.c:42
+42    /.../_Inline/build/eval_XXX_YYYY/FiltersZZZZ.c: No such file or directory.
+
+If you do set the CLEAN_AFTER_BUILD flag to false, you should see the actual
+offending C or C++ code in gdb:
+
+    use Inline C => <<'END' => CLEAN_AFTER_BUILD => 0 => FILTERS => 'Preprocess';
+    // your code here
+    END
+
+$ gdb /usr/bin/perl
+(gdb) run ./my_script.pl arg0 arg1
+...
+Thread 1 "perl" received signal SIGSEGV, Segmentation fault.
+MyPackage::my_method (this=this@entry=0x1234567, my_arg=my_arg@entry=23)
+    at /.../_Inline/build/eval_XXX_YYYY/FiltersZZZZ.c:42
+42    YOU SHOULD SEE YOUR ACTUAL OFFENDING CODE HERE
 
 =head1 DETAILS
 


### PR DESCRIPTION
This is necessary for compatibility with gdb when debugging Inline::C or Inline::CPP code which uses the Preprocess filter, see Filters.pod for example code.